### PR TITLE
Add reproducible builds configuration

### DIFF
--- a/.github/workflows/releaseExtension.yml
+++ b/.github/workflows/releaseExtension.yml
@@ -19,7 +19,16 @@ jobs:
         uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5
       - name: Build Zip
         run: ./gradlew hivemqExtensionZip
+      - name: Generate SHA256 checksum
+        run: |
+          cd build/hivemq-extension
+          sha256sum hivemq-deny-wildcard-extension-${{ github.event.release.name }}.zip | cut -d' ' -f1 > hivemq-deny-wildcard-extension-${{ github.event.release.name }}.sha256
+        run: ./gradlew hivemqExtensionZip
       - name: Upload GitHub Release Asset
         run: gh release upload ${{ github.event.release.tag_name }} ./build/hivemq-extension/hivemq-deny-wildcard-extension-${{ github.event.release.name }}.zip
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload SHA256 Checksum
+        run: gh release upload ${{ github.event.release.tag_name }} ./build/hivemq-extension/hivemq-deny-wildcard-extension-${{ github.event.release.name }}.sha256
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,3 +79,26 @@ license {
     header = rootDir.resolve("HEADER")
     mapping("java", "SLASHSTAR_STYLE")
 }
+
+// configure reproducible builds
+tasks.withType<AbstractArchiveTask>().configureEach {
+    isPreserveFileTimestamps = false
+    isReproducibleFileOrder = true
+
+    // normalize file permissions for reproducibility
+    // files: 0644 (rw-r--r--), directories: 0755 (rwxr-xr-x)
+    filePermissions {
+        unix("0644")
+    }
+    dirPermissions {
+        unix("0755")
+    }
+}
+
+tasks.withType<JavaCompile>().configureEach {
+    options.encoding = "UTF-8"
+    // ensure consistent compilation across different JDK versions
+    options.compilerArgs.addAll(listOf(
+        "-parameters" // include parameter names for reflection (improves consistency)
+    ))
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,12 @@
 version=4.1.5
+
+# reproducible builds configuration
+org.gradle.caching=true
+systemProp.file.encoding=UTF-8
+
+# JVM settings for consistent builds
+org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Duser.language=en -Duser.country=US
+
+# ensure consistent behavior across environments
+org.gradle.parallel=true
+org.gradle.daemon=true


### PR DESCRIPTION
## Summary
This PR adds reproducible builds configuration to ensure byte-identical artifacts across different build environments.

## Changes
- **build.gradle.kts**: Configure archive tasks for reproducible builds (timestamps, file order, permissions)
- **gradle.properties**: Add build cache and locale normalization
- **.github/workflows/releaseExtension.yml**: Add SHA256 checksum generation and upload for release artifacts

## What's Configured
- ✅ Normalized file timestamps (1980-02-01 00:00:00)
- ✅ Reproducible file ordering
- ✅ Normalized file permissions (0644 for files, 0755 for directories)
- ✅ UTF-8 encoding enforced
- ✅ Build cache enabled
- ✅ Locale normalization
- ✅ SHA256 checksum uploaded with releases